### PR TITLE
Use VERSION file for version detection

### DIFF
--- a/pkg/manager/detector.go
+++ b/pkg/manager/detector.go
@@ -1,33 +1,27 @@
 package manager
 
 import (
-	"bytes"
-	"errors"
 	"fmt"
-	"os/exec"
+	"io/ioutil"
 	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/go-version"
+
+	"github.com/NoizeMe/go-man/internal/fileutil"
 )
 
 func detectGoVersion(sdkDirectory string) (*version.Version, error) {
-	goBinaryPath := filepath.Join(sdkDirectory, "bin", "go")
+	versionPath := filepath.Join(sdkDirectory, "VERSION")
 
-	command := exec.Command(goBinaryPath, "version")
-	output, err := command.Output()
+	if !fileutil.PathExists(versionPath) {
+		return nil, fmt.Errorf("could not locate version file: %s", versionPath)
+	}
+
+	versionContent, err := ioutil.ReadFile(versionPath)
 	if err != nil {
 		return nil, err
 	}
 
-	var scannedVersion, osAndArch string
-	matches, err := fmt.Fscanf(bytes.NewReader(output), "go version %s %s\n", &scannedVersion, &osAndArch)
-	if err != nil {
-		return nil, err
-	}
-	if matches != 2 {
-		return nil, errors.New("could not detect go version since output did had the expected format")
-	}
-
-	return version.NewVersion(strings.TrimPrefix(scannedVersion, "go"))
+	return version.NewVersion(strings.TrimPrefix(string(versionContent), "go"))
 }

--- a/pkg/manager/detector.go
+++ b/pkg/manager/detector.go
@@ -1,22 +1,15 @@
 package manager
 
 import (
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/go-version"
-
-	"github.com/NoizeMe/go-man/internal/fileutil"
 )
 
 func detectGoVersion(sdkDirectory string) (*version.Version, error) {
 	versionPath := filepath.Join(sdkDirectory, "VERSION")
-
-	if !fileutil.PathExists(versionPath) {
-		return nil, fmt.Errorf("could not locate version file: %s", versionPath)
-	}
 
 	versionContent, err := ioutil.ReadFile(versionPath)
 	if err != nil {

--- a/pkg/manager/install_test.go
+++ b/pkg/manager/install_test.go
@@ -134,8 +134,8 @@ func TestExtractRelease(t *testing.T) {
 func TestVerifyRelease(t *testing.T) {
 	destinationDirectory := filepath.Join(t.TempDir(), "go-installation")
 	require.NoError(t, copy2.Copy(
-		filepath.Join(runtime.GOROOT(), "bin", getExecutableName("go")),
-		filepath.Join(destinationDirectory, "go", "bin", getExecutableName("go")),
+		filepath.Join(runtime.GOROOT(), "VERSION"),
+		filepath.Join(destinationDirectory, "go", "VERSION"),
 	))
 
 	validVersion := version.Must(version.NewVersion("1.15.2"))
@@ -146,12 +146,4 @@ func TestVerifyRelease(t *testing.T) {
 
 	fileutil.TryRemove(destinationDirectory)
 	assert.Error(t, verifyRelease(validVersion, destinationDirectory))
-}
-
-func getExecutableName(name string) string {
-	if runtime.GOOS == "windows" { //nolint:goconst
-		return name + ".exe"
-	}
-
-	return name
 }

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -2,11 +2,10 @@ package manager
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
-	"text/template"
 
 	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
@@ -56,63 +55,16 @@ func TestNewManager(t *testing.T) {
 func setupInstallation(t *testing.T, rootDirectory string, valid bool, goVersion fmt.Stringer) {
 	t.Helper()
 
-	folderPath := filepath.Join(rootDirectory, fmt.Sprintf("go%s", goVersion))
-	binPath := filepath.Join(folderPath, "go", "bin")
+	goVersionString := fmt.Sprintf("go%s", goVersion)
 
-	require.NoError(t, os.MkdirAll(binPath, 0700), "Could not create installation directory", folderPath)
+	sdkPath := filepath.Join(rootDirectory, goVersionString, "go")
+	versionPath := filepath.Join(sdkPath, "VERSION")
 
-	tmpl, err := template.New(getExecutableTemplateName(t)).ParseFiles(getExecutableTemplatePath(t))
-	require.NoError(t, err, "Could not render go binary template", err)
-
-	executablePath := filepath.Join(binPath, getExecutableTemplateTarget("go"))
-	file, err := os.OpenFile(executablePath, os.O_WRONLY|os.O_CREATE, 0744)
-	require.NoError(t, err, "Could not create go binary file", err)
-
-	defer func() {
-		_ = file.Close()
-	}()
-
-	parameters := struct {
-		GOVersion string
-		GOOS      string
-		GOArch    string
-		Valid     bool
-	}{goVersion.String(), runtime.GOOS, runtime.GOARCH, valid}
-
-	require.NoError(t, tmpl.Execute(file, parameters), "Could not render go binary template")
-}
-
-func getExecutableTemplateTarget(name string) string {
-	if runtime.GOOS == "windows" { //nolint:goconst
-		return name + ".bat"
+	versionContent := goVersionString
+	if !valid {
+		versionContent = "invalidContent"
 	}
 
-	return name
-}
-
-func getExecutableTemplatePath(t *testing.T) string {
-	t.Helper()
-
-	_, file, _, _ := runtime.Caller(0)
-	dir, _ := filepath.Split(file)
-
-	fileName := getExecutableTemplateName(t)
-
-	return filepath.Clean(filepath.Join(
-		dir,
-		"..",
-		"..",
-		"test",
-		fileName,
-	))
-}
-
-func getExecutableTemplateName(t *testing.T) string {
-	t.Helper()
-
-	if runtime.GOOS == "windows" {
-		return "go.bat"
-	}
-
-	return "go.sh"
+	require.NoError(t, os.MkdirAll(sdkPath, 0700), "Could not create installation directory", sdkPath)
+	require.NoError(t, ioutil.WriteFile(versionPath, []byte(versionContent), 0600))
 }


### PR DESCRIPTION
Instead of calling the go binary with the version subcommand and extract the version information from there, the VERSION file, distributed with each Go installation, is used to extract the version of a Go installation.

This is preferable, since some antivirus programs might get triggered if our process calls other programs right after the start. It should also come with less overhead and seems more robust.

Closes #14 