### PR TITLE
Cache release list

### DIFF
--- a/pkg/releases/release_client.go
+++ b/pkg/releases/release_client.go
@@ -21,6 +21,10 @@ const (
 	IncludeStable = ReleaseType("stable")
 )
 
+var (
+	releaseLists = map[ReleaseType]Collection{}
+)
+
 // SelectReleaseType is a function that returns the release type that matches the input parameters best.
 // For convenience can be used to get the correct release type by describing what kind of releases are desired and the
 // correct release type is then selected by this function. By default IncludeStable is returned.
@@ -36,12 +40,16 @@ func SelectReleaseType(unstable bool) ReleaseType {
 // This list is retrieved by querying a JSON endpoint that is provided by the official Golang website. If the endpoint
 // responds with any other status code than 200, an error is returned.
 func ListAll(releaseType ReleaseType) (Collection, error) {
-	versions := make([]*Release, 0)
-	if err := httputil.GetJSON(fmt.Sprintf(releaseListURLTemplate, releaseType), &versions); err != nil {
-		return nil, err
+	if _, ok := releaseLists[releaseType]; !ok {
+		newReleaseList := Collection{}
+		if err := httputil.GetJSON(fmt.Sprintf(releaseListURLTemplate, releaseType), &newReleaseList); err != nil {
+			return nil, err
+		}
+
+		releaseLists[releaseType] = newReleaseList
 	}
 
-	return versions, nil
+	return releaseLists[releaseType], nil
 }
 
 // GetLatest is a function that retrieves the latest release of the Golang SDK.

--- a/pkg/releases/release_client_test.go
+++ b/pkg/releases/release_client_test.go
@@ -32,12 +32,14 @@ func TestListAll(t *testing.T) {
 	assert.Greater(t, len(allReleases), len(stableReleases))
 
 	httputil.Client = httputil.StaticResponseClient(500, nil, errors.New("failure"))
+	delete(releaseLists, IncludeStable)
 
 	stableReleases, err = ListAll(IncludeStable)
 	assert.Error(t, err)
 	assert.Empty(t, stableReleases)
 
 	httputil.Client = httputil.StaticResponseClient(404, []byte("not found"), nil)
+	delete(releaseLists, IncludeStable)
 
 	stableReleases, err = ListAll(IncludeStable)
 	assert.Error(t, err)
@@ -58,12 +60,14 @@ func TestGetLatest(t *testing.T) {
 	assert.NotNil(t, latestAll)
 
 	httputil.Client = httputil.StaticResponseClient(500, nil, errors.New("failure"))
+	delete(releaseLists, IncludeStable)
 
 	latestStable, err = GetLatest(IncludeStable)
 	assert.Error(t, err)
 	assert.Nil(t, latestStable)
 
 	httputil.Client = httputil.StaticResponseClient(404, []byte("not found"), nil)
+	delete(releaseLists, IncludeStable)
 
 	latestStable, err = GetLatest(IncludeStable)
 	assert.Error(t, err)
@@ -87,6 +91,7 @@ func TestGetForVersion(t *testing.T) {
 	assert.Nil(t, release)
 
 	httputil.Client = httputil.StaticResponseClient(500, nil, errors.New("failure"))
+	delete(releaseLists, IncludeAll)
 
 	release, exists, err = GetForVersion(IncludeAll, version.Must(version.NewVersion("1.12.16")))
 	assert.Error(t, err)
@@ -94,6 +99,7 @@ func TestGetForVersion(t *testing.T) {
 	assert.Nil(t, release)
 
 	httputil.Client = httputil.StaticResponseClient(404, []byte("not found"), nil)
+	delete(releaseLists, IncludeAll)
 
 	release, exists, err = GetForVersion(IncludeAll, version.Must(version.NewVersion("1.12.16")))
 	assert.Error(t, err)


### PR DESCRIPTION
The list of Go releases is retrieved multiple times during the execution of some tasks. As a small improvement, mainly to not put so much traffic on the golang servers, the release list is now cached in-memory during the execution of a single task.

Closes #9