### PR TITLE
Rename goman to gmn

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,9 +71,9 @@ jobs:
       - name: Build
         run: |
           export GO111MODULE=on
-          GOOS=darwin  GOARCH=amd64 go build -o bin/goman-ci-darwin-amd64      cmd/goman/main.go
-          GOOS=linux   GOARCH=amd64 go build -o bin/goman-ci-linux-amd64       cmd/goman/main.go
-          GOOS=windows GOARCH=amd64 go build -o bin/goman-ci-windows-amd64.exe cmd/goman/main.go
+          GOOS=darwin  GOARCH=amd64 go build -o bin/gmn-ci-darwin-amd64      cmd/gmn/main.go
+          GOOS=linux   GOARCH=amd64 go build -o bin/gmn-ci-linux-amd64       cmd/gmn/main.go
+          GOOS=windows GOARCH=amd64 go build -o bin/gmn-ci-windows-amd64.exe cmd/gmn/main.go
       - name: Upload Artifacts
         uses: actions/upload-artifact@master
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,9 +3,9 @@ before:
     - go mod download
 
 builds:
-  - id: "goman-cli"
-    main: ./cmd/goman/main.go
-    binary: goman
+  - id: "gmn-cli"
+    main: ./cmd/gmn/main.go
+    binary: gmn
     env:
       - CGO_ENABLED=0
       - GO111MODULE=on
@@ -15,17 +15,17 @@ builds:
       - darwin
 
 archives:
-  - name_template: "goman{{ .Version }}.{{ .Os }}-{{ .Arch }}"
+  - name_template: "gmn{{ .Version }}.{{ .Os }}-{{ .Arch }}"
     format_overrides:
       - goos: windows
         format: zip
 
 source:
   enabled: true
-  name_template: "goman{{ .Version }}.src"
+  name_template: "gmn{{ .Version }}.src"
 
 checksum:
-  name_template: "goman{{ .Version }}.checksums.txt"
+  name_template: "gmn{{ .Version }}.checksums.txt"
 
 milestones:
   - close: true

--- a/cmd/gmn/main.go
+++ b/cmd/gmn/main.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	root = cmd.New(
-		cmd.OptName("goman"),
+		cmd.OptName("gmn"),
 		cmd.OptDetails("A manager for Go installations"),
 	)
 
@@ -187,15 +187,15 @@ func handleCleanup(task *tasks.Task) {
 }
 
 func gomanRoot() string {
-	root := os.Getenv("GOMANROOT")
+	root := os.Getenv("GMNROOT")
 	if len(root) > 0 {
 		return root
 	}
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return filepath.Join("/", ".goman")
+		return filepath.Join("/", ".gmn")
 	}
 
-	return filepath.Join(homeDir, ".goman")
+	return filepath.Join(homeDir, ".gmn")
 }


### PR DESCRIPTION
To prevent confusion or conflicts with another project called goman, I decided to rename the executable to gmn. The project name itself will remain goman for now.