### PR TITLE
Use links for selecting on windows without admin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/gookit/color v1.3.1
 	github.com/hashicorp/go-version v1.2.1
 	github.com/mholt/archiver/v3 v3.3.0
-	github.com/otiai10/copy v1.2.0
 	github.com/posener/cmd v1.3.4
 	github.com/posener/complete/v2 v2.0.1-alpha.12
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -29,14 +29,6 @@ github.com/mholt/archiver/v3 v3.3.0 h1:vWjhY8SQp5yzM9P6OJ/eZEkmi3UAbRrxCq48MxjAz
 github.com/mholt/archiver/v3 v3.3.0/go.mod h1:YnQtqsp+94Rwd0D/rk5cnLrxusUBUXg+08Ebtr1Mqao=
 github.com/nwaples/rardecode v1.0.0 h1:r7vGuS5akxOnR4JQSkko62RJ1ReCMXxQRPtxsiFMBOs=
 github.com/nwaples/rardecode v1.0.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
-github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
-github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
-github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
-github.com/otiai10/curr v1.0.0 h1:TJIWdbX0B+kpNagQrjgq8bCMrbhiuX73M2XwgtDMoOI=
-github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
-github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
-github.com/otiai10/mint v1.3.1 h1:BCmzIS3n71sGfHB5NMNDB3lHYPz8fWSkCAErHed//qc=
-github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/manager/select_win.go
+++ b/pkg/manager/select_win.go
@@ -21,7 +21,10 @@ func link(sourceDirectory, targetDirectory string) error {
 		return os.Symlink(sourceDirectory, targetDirectory)
 	}
 
-	return exec.Command("mklink", "/J", targetDirectory, sourceDirectory).Run()
+	command := exec.Command("cmd", "/c", "mklink", "/J", targetDirectory, sourceDirectory)
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	return command.Run()
 }
 
 func unlink(directory string) error {

--- a/pkg/manager/select_win.go
+++ b/pkg/manager/select_win.go
@@ -21,10 +21,7 @@ func link(sourceDirectory, targetDirectory string) error {
 		return os.Symlink(sourceDirectory, targetDirectory)
 	}
 
-	command := exec.Command("cmd", "/c", "mklink", "/J", targetDirectory, sourceDirectory)
-	command.Stdout = os.Stdout
-	command.Stderr = os.Stderr
-	return command.Run()
+	return exec.Command("cmd", "/c", "mklink", "/J", targetDirectory, sourceDirectory).Run()
 }
 
 func unlink(directory string) error {

--- a/pkg/manager/select_win.go
+++ b/pkg/manager/select_win.go
@@ -5,8 +5,8 @@ package manager
 import (
 	"fmt"
 	"os"
+	"os/exec"
 
-	"github.com/otiai10/copy"
 	"golang.org/x/sys/windows"
 
 	"github.com/NoizeMe/go-man/internal/fileutil"
@@ -21,7 +21,7 @@ func link(sourceDirectory, targetDirectory string) error {
 		return os.Symlink(sourceDirectory, targetDirectory)
 	}
 
-	return copy.Copy(sourceDirectory, targetDirectory)
+	return exec.Command("mklink", "/J", targetDirectory, sourceDirectory).Run()
 }
 
 func unlink(directory string) error {


### PR DESCRIPTION
When selecting on windows without admin privileges, it is quit tricky to link the selected installation, without copying the whole SDK. This commit changes this behaviour by using the 'mklink' command, which should work just as well.